### PR TITLE
Fix keybinding options selection

### DIFF
--- a/HunterEngage_Options.lua
+++ b/HunterEngage_Options.lua
@@ -172,6 +172,6 @@ function HunterEngage:SetupOptions()
         self:Print("|cff99ff99New keybind set to [" .. bind .. "]|r")
 
         self:SetupSecureButton()
-        AceConfigDialog:SelectGroup("Hunter Engage")
+        AceConfigDialog:SelectGroup(addonName)
     end)
 end


### PR DESCRIPTION
This pull request includes a small change to the `HunterEngage_Options.lua` file. The change updates a function call to use the `addonName` variable instead of the hardcoded string `"Hunter Engage"` when selecting the configuration group.

* [`HunterEngage_Options.lua`](diffhunk://#diff-468aa9b95d1d06a7d099d1d10e1e9eeef42420cb1a305c41d6a3bbb08ac4f24fL175-R175): Updated `AceConfigDialog:SelectGroup` to use the `addonName` variable, improving maintainability and consistency.